### PR TITLE
fix: version handling

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -9,17 +9,16 @@ ASDF_INSTALL_TYPE=${ASDF_INSTALL_TYPE:-version}
 [ -n "$ASDF_INSTALL_PATH" ] || (>&2 echo 'Missing ASDF_INSTALL_PATH' && exit 1)
 
 install_plugin() {
-  local install_type=$1
   local version=$2
   local install_path=$3
-  local download_url="$(get_download_url $install_type $version)"
+  local download_url="$(get_download_url $version)"
   local tmp_download_file=$(mktemp)
 
   local bin_install_path="$install_path/bin"
   mkdir -p "${bin_install_path}"
 
   echo "Downloading k9s from $download_url"
-  curl -L -s "$download_url" -o "$tmp_download_file"
+  curl -sL "$download_url" -o "$tmp_download_file"
   pushd $bin_install_path > /dev/null
   tar zxf "$tmp_download_file" || exit 1
   popd > /dev/null
@@ -34,9 +33,8 @@ get_arch() {
 }
 
 get_download_url() {
-  local install_type=$1
-  local tag=$2
-  local version=$2
+  local tag=$1
+  local version=$1
 
   # releases after 0.1.12 changed tag/version convention
   # the tag contains "v*" whereas the file download does not

--- a/bin/install
+++ b/bin/install
@@ -36,7 +36,7 @@ get_download_url() {
   local tag=$1
   local version=$1
 
-  # releases after 0.1.12 changed tag/version convention
+  # releases from 0.13.0 changed tag/version convention
   # the tag contains "v*" whereas the file download does not
   if [[ "$version" == v* ]]; then
     version=${version:1} # remove leading "v"
@@ -45,7 +45,12 @@ get_download_url() {
   local platform=$(get_platform)
   local arch=$(get_arch)
 
-  echo "https://github.com/derailed/k9s/releases/download/${tag}/k9s_${version}_${platform}_${arch}.tar.gz"
+  # releases from 0.14.0 do not have version in the binary
+  if [ "$(printf '%s\n' "0.14.0" "$version" | sort -rV | head -n1)" = "$version" ]; then
+    echo "https://github.com/derailed/k9s/releases/download/${tag}/k9s_${platform}_${arch}.tar.gz"
+  else
+    echo "https://github.com/derailed/k9s/releases/download/${tag}/k9s_${version}_${platform}_${arch}.tar.gz"
+  fi
 }
 
 install_plugin "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -3,24 +3,23 @@
 set -e
 # set -x
 
-get_platform() {
-  [ "Linux" = "$(uname)" ] && echo "linux64" || echo "osx-amd64"
-}
-
 releases_path=https://api.github.com/repos/derailed/k9s/releases
 cmd="curl -sL"
-if [ -n "$OAUTH_TOKEN" ]; then
+
+if [ -n "$GITHUB_API_TOKEN" ]; then
+  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
+elif [ -n "$OAUTH_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $OAUTH_TOKEN'"
 fi
+
 cmd="$cmd $releases_path"
 
-# need jq; download portable version if not installed
-if [ -z "$(command -v jq)" ]; then
-  curl -L -s "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-$(get_platform)" -o jq
-  chmod +x jq
-fi
+# From https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
+function sort_versions() {
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+}
 
-# fetch all tag names
-# want just the version numbers, no "v" in front
-versions=$(eval $cmd | jq -r '.[].tag_name' | sed 's/^[v]//' | sort --version-sort)
+# Fetch all tag names, and get only second column. Then remove all unnecesary characters.
+versions=$(eval $cmd | grep -oE "tag_name\":\s?\".*\"," | sed 's/tag_name\": *\"//;s/\",//' | sort_versions)
 echo $versions


### PR DESCRIPTION
Thanks for putting this together! I encountered a few problems due to the fact that k9s changed versioning/binary publishing lately, so this PR brings fixes for that.

- from `0.14.0` version is removed from a binary name so the script adjust to that
- `list-all` does not need `jq` so I put together jq-free version which I also use in my asdf plugins
- `install_type` is unused in `get_download_url` so I cleaned that up